### PR TITLE
feat: Added new region 'me1' to Region enum in clients.py

### DIFF
--- a/pulsefire/clients.py
+++ b/pulsefire/clients.py
@@ -349,7 +349,7 @@ class RiotAPIClient(BaseClient):
 
     Region = Literal[
         "americas", "europe", "asia", "sea", "esports",
-        "br1", "eun1", "euw1", "jp1", "kr", "la1", "la2",
+        "br1", "eun1", "euw1", "jp1", "kr", "la1", "la2", "me1"
         "na1", "oc1", "tr1", "ru", "ph2", "sg2", "th2", "tw2", "vn2",
         "ap", "br", "eu", "kr", "latam", "na",
     ] | _str


### PR DESCRIPTION
This PR adds the new 'me1' region that was [introduced on June 26, 2024](https://x.com/RiotGamesDevRel/status/1805992105187463538) to the Region enum in clients.py.

Specifically, this change:
* Updates `pulsefire/clients.py`: Adds the `"me1"` region code to the `Region` type in the `RiotAPIClient` class.