### PR TITLE
Added support for the GetActiveRegion Endpoint.

### DIFF
--- a/pulsefire/clients.py
+++ b/pulsefire/clients.py
@@ -389,6 +389,9 @@ class RiotAPIClient(BaseClient):
     async def get_account_v1_active_shard_by_puuid(self, *, region: Region = ..., puuid: str = ..., game: str = ...) -> RiotAPISchema.AccountV1ActiveShard:
         return await self.invoke("GET", "/riot/account/v1/active-shards/by-game/{game}/by-puuid/{puuid}")
 
+    async def get_account_v1_active_region_by_puuid(self, *, region: Region = ..., puuid: str = ..., game: str = ...) -> RiotAPISchema.AccountV1ActiveRegion:
+        return await self.invoke("GET", "/riot/account/v1/region/by-game/{game}/by-puuid/{puuid}")
+
     # League of Legends Endpoints
 
     async def get_lol_champion_v3_rotation(self, *, region: Region = ...) -> RiotAPISchema.LolChampionV3Rotation:

--- a/pulsefire/schemas.py
+++ b/pulsefire/schemas.py
@@ -638,6 +638,11 @@ class RiotAPISchema:
         "game": str,
         "activeShard": str,
     })
+    AccountV1ActiveRegion = TypedDict("AccountV1ActiveRegion", {
+        "puuid": str,
+        "game": str,
+        "region": str,
+    })
 
     # League of Legends Types
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -89,6 +89,7 @@ async def test_acc_riot_api_client():
         account = await client.get_account_v1_by_riot_id(region="americas", game_name="200", tag_line="16384")
         await client.get_account_v1_by_puuid(region="americas", puuid=account["puuid"])
         await client.get_account_v1_active_shard_by_puuid(region="americas", puuid=account["puuid"], game="val")
+        await client.get_account_v1_active_region_by_puuid(region="americas", puuid=account["puuid"], game="lol")
 
 
 @async_to_sync()


### PR DESCRIPTION
#17 
Added the endpoint to get the active region per puuid for LoL/TFT, which is necessary for tracking account transfers.